### PR TITLE
open config file in local EDITOR, if user is connected via SSH

### DIFF
--- a/src/include/filesystem.js
+++ b/src/include/filesystem.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const open = require('open');
 const find = require('find-in-files');
+const child_process = require('child_process');
 
 class filesystem {
     static find(pattern, dir) {
@@ -22,7 +23,14 @@ class filesystem {
     }
 
     static open(file) {
+      if ((process.env.SSH_CLIENT || process.env.SSH_TTY) && process.env.EDITOR) {
+        var child = child_process.spawn(process.env.EDITOR, [file], {
+          stdio: 'inherit'
+        });
+        return child;
+      } else {
         return open(file);
+      }
     }
 
     static join(...args) {


### PR DESCRIPTION
I am always working remotely on a linux server machine.

Thus, opening via the node-open doesn't work, the "gtt config" will never return.

When I am using ``xdb-open path-to-config.js`` (what the node-open package does under the hood), I am getting these messags:

```
$ xdg-open src/gtt-config.js      
Error: no "view" mailcap rules found for type "application/javascript"
Opening "src/gtt-config.js" with Neovim  (application/javascript)
xterm: Xt error: Can't open display:
xterm: DISPLAY is not set
/usr/bin/xdg-open: 461: /usr/bin/xdg-open: links2: not found
/usr/bin/xdg-open: 461: /usr/bin/xdg-open: links: not found
/usr/bin/xdg-open: 461: /usr/bin/xdg-open: lynx: not found
(...then w3m starts to "download" the file...)
```

AFAIK the whole xdg stuff is for GUI apps/multi terminal environments. For a terminal application, i would expect it to open in the EDITOR environment variable, like ``git commit`` does.

The proposed change checks the environment for known SSH variables [(1)][1]. If those and the EDITOR is found, that is launched instead.

[1]: https://unix.stackexchange.com/questions/9605/how-can-i-detect-if-the-shell-is-controlled-from-ssh