### PR TITLE
Fix configuration directory permissions

### DIFF
--- a/src/include/file-config.js
+++ b/src/include/file-config.js
@@ -82,9 +82,9 @@ class fileConfig extends config {
     }
 
     assertGlobalConfig() {
-        if (!fs.existsSync(this.globalDir)) fs.mkdirSync(this.globalDir, '0644', true);
-        if (!fs.existsSync(this.frameDir)) fs.mkdirSync(this.frameDir, '0744', true);
-        if (!fs.existsSync(this.cacheDir)) fs.mkdirSync(this.cacheDir, '0744', true);
+        if (!fs.existsSync(this.globalDir)) fs.mkdirSync(this.globalDir, '0750', true);
+        if (!fs.existsSync(this.frameDir)) fs.mkdirSync(this.frameDir, '0750', true);
+        if (!fs.existsSync(this.cacheDir)) fs.mkdirSync(this.cacheDir, '0750', true);
         if (!fs.existsSync(this.global)) fs.appendFileSync(this.global, '');
     }
 


### PR DESCRIPTION
When you run `gtt config` for the first time, it will crash with the error below:

```
fs.js:932
  return binding.mkdir(pathModule._makeLong(path),
                 ^

Error: EACCES: permission denied, mkdir '/home/bobvandevijver/.gtt/frames'
    at Error (native)
    at Object.fs.mkdirSync (fs.js:932:18)
    at fileConfig.assertGlobalConfig (/usr/lib/node_modules/gitlab-time-tracker/src/include/file-config.js:86:47)
    at new fileConfig (/usr/lib/node_modules/gitlab-time-tracker/src/include/file-config.js:20:14)
    at Object.<anonymous> (/usr/lib/node_modules/gitlab-time-tracker/src/gtt-config.js:6:14)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

which is due to missing execute permissions on the directory (tested on Debian Stretch). By adding the execute bit to the directory (and removing anonymous access), this is fixed.