### PR TITLE
Add support for the 'due date' field of issues

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -409,7 +409,7 @@ gtt report --issue_columns=iid --issue_columns=title --issue_columns=time_userna
 
 *Note: Available columns to choose from: `id`, `iid`, `title`, `project_id`, 
 `project_namespace`, `description`, `labels`, `milestone`, `assignee`, `author`,
-`closed`, `updated_at`, `created_at`, `state`, `spent`, `total_spent`, `total_estimate`*
+`closed`, `updated_at`, `created_at`, `due_date`, `state`, `spent`, `total_spent`, `total_estimate`*
 
 *You can also include columns that show the total time spent by a specific user 
 by following this convention: `time_username`*

--- a/src/models/issue.js
+++ b/src/models/issue.js
@@ -90,6 +90,10 @@ class issue extends hasTimes {
         return this.config.toHumanReadable(this.timeSpent, this._type);
     }
 
+    get due_date() {
+        return this.data.due_date ? moment(this.data.due_date): null;
+    }
+
     get total_spent() {
         return this.stats ? this.config.toHumanReadable(this.stats.total_time_spent, this._type) : null;
     }


### PR DESCRIPTION
Added possibility to use the due date field of issues as a column in issue reports. Null is returned for issues that do not have a due date set.