### PR TITLE
fix issue #70 - numeric cells showing up as strings in xlsx output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-time-tracker",
-  "version": "1.7.22",
+  "version": "1.7.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/output/xlsx.js
+++ b/src/output/xlsx.js
@@ -87,6 +87,22 @@ class xlsx extends Base {
     toStdOut() {
         Cli.error(`Can't output xlsx to std out`);
     }
+
+    /**
+     * prepare the given object by converting numeric
+     * columns/properties as numbers instead of strings
+     * on top of what the parent method already does
+     *
+     * suboptimally done here to avoid impacts on other outputs
+     *
+     * @param obj
+     * @param columns
+     * @returns {Array}
+     */
+    prepare(obj = {}, columns = []) {
+        let formattedObj = super.prepare(obj, columns);
+        return formattedObj.map(field => isNaN(field) ? field : Number(field));
+    }
 }
 
 module.exports = xlsx;


### PR DESCRIPTION
Fixed by converting all numeric value cells (checked by isNaN), irrespective of column, to a Number cell.