### PR TITLE
issue data does not have "closed" property

### DIFF
--- a/src/models/issue.js
+++ b/src/models/issue.js
@@ -71,7 +71,7 @@ class issue extends hasTimes {
     }
 
     get closed() {
-        return !!this.data.closed;
+        return this.data.state === 'closed';
     }
 
     get updated_at() {


### PR DESCRIPTION
gitlab api does not have ```closed``` property in the json data.
```state``` property contains either ```closed``` or ```opened``` value instead.
Please, refer https://docs.gitlab.com/ee/api/issues.html