### PR TITLE
Add support for 'closed at' and 'merged at' fields

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -399,7 +399,7 @@ gtt report --issue_columns=iid --issue_columns=title --issue_columns=time_userna
 
 *Note: Available columns to choose from: `id`, `iid`, `title`, `project_id`, 
 `project_namespace`, `description`, `labels`, `milestone`, `assignee`, `author`,
-`closed`, `updated_at`, `created_at`, `due_date`, `state`, `spent`, `total_spent`, `total_estimate`*
+`closed`, `updated_at`, `created_at`, `closed_at`, `due_date`, `state`, `spent`, `total_spent`, `total_estimate`*
 
 *You can also include columns that show the total time spent by a specific user 
 by following this convention: `time_username`*
@@ -412,7 +412,7 @@ gtt report --merge_request_columns=iid --merge_request_columns=title --merge_req
 
 *Note: Available columns to choose from: `id`, `iid`, `title`, `project_id`,
 `project_namespace`, `description`, `labels`, `milestone`, `assignee`, `author`,
-`updated_at`, `created_at`, `state`, `spent`, `total_spent`, `total_estimate`*
+`updated_at`, `created_at`, `closed_at`, `merged_at`, `state`, `spent`, `total_spent`, `total_estimate`*
 
 *You can also include columns that show the total time spent by a specific user 
 by following this convention: `time_username`*

--- a/src/models/issue.js
+++ b/src/models/issue.js
@@ -94,6 +94,10 @@ class issue extends hasTimes {
         return this.data.due_date ? moment(this.data.due_date): null;
     }
 
+    get closed_at() {
+        return this.data.closed_at ? moment(this.data.closed_at): null;
+    }
+
     get total_spent() {
         return this.stats ? this.config.toHumanReadable(this.stats.total_time_spent, this._type) : null;
     }

--- a/src/models/mergeRequest.js
+++ b/src/models/mergeRequest.js
@@ -75,6 +75,14 @@ class mergeRequest extends hasTimes {
         return moment(this.data.created_at);
     }
 
+    get merged_at() {
+        return this.data.merged_at ? moment(this.data.merged_at): null;
+    }
+
+    get closed_at() {
+        return this.data.closed_at ? moment(this.data.closed_at): "not closed"
+    }
+
     get state() {
         return this.data.state;
     }

--- a/src/models/mergeRequest.js
+++ b/src/models/mergeRequest.js
@@ -1,4 +1,5 @@
 const hasTimes = require('./hasTimes');
+const moment = require('moment');
 
 /**
  * merge request model


### PR DESCRIPTION
Adds `closed_at` for issues, `closed_at` and `merged_at` for merge requests.
Returns null is not closed or merged.

Also fixes issue with `updated_at` and `created_at` not working in merge requests due to the `moment` module not being imported.