### PR TITLE
Fix rate limit of 600 requests per minutes on Gitlab.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "request-promise-native": "^1.0.4",
     "shelljs": "^0.8.3",
     "tempfile": "^2.0.0",
+    "throttled-queue": "^1.0.7",
     "underscore": "^1.9.1",
     "xdg-basedir": "^3.0.0",
     "xlsx": "^0.13.5"

--- a/src/models/base.js
+++ b/src/models/base.js
@@ -2,9 +2,7 @@ const request = require('request-promise-native');
 const url = require('url');
 const async = require('async');
 const crypto = require('crypto');
-const throttledQueue = require('throttled-queue');
-
-const throttle = throttledQueue(10, 1000);
+const throttle = require('throttled-queue')(10, 1000);
 
 /**
  * base model
@@ -38,23 +36,21 @@ class base {
 
         data.private_token = this.token;
 
-        return new Promise((resolve, reject) => {
-            throttle(() => {
-              request.post(`${this.url}${path}`, {
-                  json: true,
-                  body: data,
-                  insecure: this._insecure,
-                  proxy: this._proxy,
-                  resolveWithFullResponse: true,
-                  headers: {
-                      'PRIVATE-TOKEN': this.token
-                  }
-              }).then(response => {
-                  if (this.config.get('_createDump')) this.setDump(response, key);
-                  resolve(response);
-              }).catch(e => reject(e));
-            })
-        });
+        return new Promise((resolve, reject) => throttle(() => {
+            request.post(`${this.url}${path}`, {
+                json: true,
+                body: data,
+                insecure: this._insecure,
+                proxy: this._proxy,
+                resolveWithFullResponse: true,
+                headers: {
+                    'PRIVATE-TOKEN': this.token
+                }
+            }).then(response => {
+                if (this.config.get('_createDump')) this.setDump(response, key);
+                resolve(response);
+            }).catch(e => reject(e));
+        }));
     }
 
     /**
@@ -71,22 +67,20 @@ class base {
         path += (path.includes('?') ? '&' : '?') + `private_token=${this.token}`;
         path += `&page=${page}&per_page=${perPage}`;
 
-        return new Promise((resolve, reject) => {
-            throttle(() => {
-              request(`${this.url}${path}`, {
-                  json: true,
-                  insecure: this._insecure,
-                  proxy: this._proxy,
-                  resolveWithFullResponse: true,
-                  headers: {
-                      'PRIVATE-TOKEN': this.token
-                  }
-              }).then(response => {
-                  if (this.config.get('_createDump')) this.setDump(response, key);
-                  resolve(response);
-              }).catch(e => reject(e));
-            })
-        });
+        return new Promise((resolve, reject) => throttle(() => {
+            request(`${this.url}${path}`, {
+                json: true,
+                insecure: this._insecure,
+                proxy: this._proxy,
+                resolveWithFullResponse: true,
+                headers: {
+                    'PRIVATE-TOKEN': this.token
+                }
+            }).then(response => {
+                if (this.config.get('_createDump')) this.setDump(response, key);
+                resolve(response);
+            }).catch(e => reject(e));
+        }));
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,6 +2429,11 @@ text-encoding@0.6.4, text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
+throttled-queue@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/throttled-queue/-/throttled-queue-1.0.7.tgz#da7ed6702941993044a1c5fd2ac3a58582dd2977"
+  integrity sha512-/HT49S7m+NvdyJMoMRzIYlawKjeHn8jEc8TZaGmFi5IBu09hIiU/QoP1zcrB9X2qsVC11PgfRfqd8zEQs7PlEA==
+
 throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"


### PR DESCRIPTION
This is a simple fix, maximum of 10 requests per seconds = maximum of 600 requests per minutes. It does slow down a bit the report but it prevent a fatal error. It's possible to design a more sophisticated fix but it will be more complex with more states to manage. It would be more prone to bugs. I favor simplicity over maximum speed.