### PR TITLE
Add pwd to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR /pwd
 RUN yarn global add --prefix /usr/local "gitlab-time-tracker@$GTT_VERSION"
 
 VOLUME ["/root", "/pwd"]
-ENTRYPOINT ["gtt", ""]
+ENTRYPOINT ["gtt"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM node:8.2.1-alpine
 
 ENV GTT_VERSION 1.7.39
 
+WORKDIR /pwd
+
 RUN yarn global add --prefix /usr/local "gitlab-time-tracker@$GTT_VERSION"
 
-VOLUME ["/root"]
-ENTRYPOINT ["gtt"]
+VOLUME ["/root", "/pwd"]
+ENTRYPOINT ["gtt", ""]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:8.2.1-alpine
 
 ENV GTT_VERSION 1.7.39
+ENV EDITOR vi
 
 WORKDIR /pwd
 

--- a/documentation.md
+++ b/documentation.md
@@ -102,7 +102,7 @@ docker run \
 I highly recommend creating an alias and adding it to your `bashrc`:
  
 ```shell
-echo "alias gtt='docker run --rm -it -v ~:/root kriskbx/gitlab-time-tracker'" >>~/.bashrc
+echo "alias gtt='docker run --rm -it -v ~:/root -v $(pwd):/pwd kriskbx/gitlab-time-tracker'" >>~/.bashrc
 ```
 
 Now you can simply write `gtt` instead of the bulky Docker command before. Try it out: `gtt --help`

--- a/documentation.md
+++ b/documentation.md
@@ -76,7 +76,7 @@ docker run \
 ```
 
 `--rm` removes the container after running, `-it` makes it interactive, `-v ~:/root` mounts your home directory to the
-home directory inside the container, `-v ~$(pwd):/pwd` mounts current directory inside the container to gtt be able to read local config. If you want to store the config in another place, mount another directory: 
+home directory inside the container, `-v $(pwd):/pwd` mounts current directory inside the container to gtt be able to read local config. If you want to store the config in another place, mount another directory: 
  
  
  ```shell

--- a/documentation.md
+++ b/documentation.md
@@ -70,12 +70,13 @@ you can use the official [Docker image](https://hub.docker.com/r/kriskbx/gitlab-
 docker run \
        --rm -it \
        -v ~:/root \
+       -v $(pwd):/pwd \
        kriskbx/gitlab-time-tracker \
        --help
 ```
 
 `--rm` removes the container after running, `-it` makes it interactive, `-v ~:/root` mounts your home directory to the
-home directory inside the container. If you want to store the config in another place, mount another directory: 
+home directory inside the container, `-v ~$(pwd):/pwd` mounts current directory inside the container to gtt be able to read local config. If you want to store the config in another place, mount another directory: 
  
  
  ```shell


### PR DESCRIPTION
Allows the use of current dir `.gtt.yml` inside the docker container.