### PR TITLE
Run gtt as a non priveleged user in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,14 @@ FROM node:8.2.1-alpine
 ENV GTT_VERSION 1.7.39
 ENV EDITOR vi
 
-WORKDIR /pwd
 
-RUN yarn global add --prefix /usr/local "gitlab-time-tracker@$GTT_VERSION"
+RUN apk update && \
+    apk add git && \
+    addgroup -S gtt && adduser -S gtt -G gtt && \
+    yarn global add --prefix /usr/local "gitlab-time-tracker@$GTT_VERSION"
+USER gtt
+WORKDIR /home/gtt
 
-VOLUME ["/root", "/pwd"]
+VOLUME ["/home/gtt"]
 ENTRYPOINT ["gtt"]
 CMD ["--help"]

--- a/documentation.md
+++ b/documentation.md
@@ -69,40 +69,36 @@ you can use the official [Docker image](https://hub.docker.com/r/kriskbx/gitlab-
 ```shell
 docker run \
        --rm -it \
-       -v ~:/root \
-       -v $(pwd):/pwd \
+       -v ~/.local/share/.gtt/:/home/gtt/.local/share/.gtt \
        kriskbx/gitlab-time-tracker \
        --help
 ```
 
-`--rm` removes the container after running, `-it` makes it interactive, `-v ~:/root` mounts your home directory to the
-home directory inside the container, `-v $(pwd):/pwd` mounts current directory inside the container to gtt be able to read local config. If you want to store the config in another place, mount another directory: 
+`--rm` removes the container after running, `-it` makes it interactive, `-v ~/.local/share/.gtt/:/home/gtt/.local/share/.gtt ` mounts your gtt configuration directory in the gtt user home directory inside the container. For example, to run a report for a particular user with a date range:
+
+```shell
+sudo docker run \
+       --rm -it \
+       -v ~/.local/share/.gtt/:/home/gtt/.local/share/.gtt \
+       kriskbx/gitlab-time-tracker \
+       report "ourorganization/aproject" --user=xxxx --from="2020-04-01" --to="2020-06-30"
+```
+
+If you want to store the config in another place, mount another directory: 
  
  
  ```shell
  docker run \
         --rm -it \
-        -v /path/to/gtt-config:/root \
+        -v /path/to/gtt-config-dir:/home/gtt/.local/share/.gtt \
         kriskbx/gitlab-time-tracker \
         --help
  ```
 
-... or use a Docker volume:
-
-```shell
-docker volume create gtt-config
-
-docker run \
-      --rm -it \
-      -v gtt-config:/root \
-      kriskbx/gitlab-time-tracker \
-      --help
-```
- 
 I highly recommend creating an alias and adding it to your `bashrc`:
  
 ```shell
-echo "alias gtt='docker run --rm -it -v ~:/root -v $(pwd):/pwd kriskbx/gitlab-time-tracker'" >>~/.bashrc
+echo "alias gtt='docker run --rm -it -v -v ~/.local/share/.gtt/:/home/gtt/.local/share/.gtt kriskbx/gitlab-time-tracker'" >>~/.bashrc
 ```
 
 Now you can simply write `gtt` instead of the bulky Docker command before. Try it out: `gtt --help`


### PR DESCRIPTION
Hi,

This PR fixes issue #104 , as PR #108 does not correctly set the volumes to access the gtt configuration file without having to mount the complete user home directory which is a security risk. It also uses a non privileged user to run gtt instead of the root user, which is also a security risk.