### PR TITLE
Fix gtt-report missing data from projects

### DIFF
--- a/src/models/owner.js
+++ b/src/models/owner.js
@@ -121,9 +121,9 @@ class owner extends Base {
      */
     getProjectsByGroup() {
         return this.parallel(this.groups, (group, done) => {
-            this.get(`groups/${group.id}/projects`)
+            this.all(`groups/${group.id}/projects`)
                 .then(projects => {
-                    this.projects = this.projects.concat(projects.body);
+                    this.projects = projects;
                     done();
                 })
                 .catch(e => done(e));


### PR DESCRIPTION
When groups have more than 100 projects, the gtt-report for groups doesn't paginate the project requests.