### PR TITLE
#126: Report: Add noteable title to time record

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -558,6 +558,7 @@ mergeRequestColumns:
 recordColumns:
 - user
 - iid
+- title
 - time
 
 # Add columns for each project member to issue and

--- a/spec/models/time.title.spec.js
+++ b/spec/models/time.title.spec.js
@@ -1,0 +1,36 @@
+const moment = require('moment');
+const Config = require('../../src/include/config');
+const Time = require('./../../src/models/time');
+const issue = require('../../src/models/issue');
+const mergeRequest = require('../../src/models/mergeRequest');
+const expect = require('chai').expect;
+
+describe('time class', () => {
+    it('Returns title of parent Issue', () => {
+        const config = new Config();
+        const parent = new issue(config, {title: "Test title"})
+        const time = new Time('1h', moment(), {}, parent,  config);
+
+        expect(time.title).to.be.equal("Test title");
+    });
+
+    it('Returns title of parent MergeRequest', () => {
+        const config = new Config();
+        const parent = new mergeRequest(config, {title: "Test title"})
+        const time = new Time('1h', moment(), {}, parent,  config);
+
+        expect(time.title).to.be.equal("Test title");
+    });
+
+    it('Returns Null for missed title or parent', () => {
+        const config = new Config();
+        const parent = new mergeRequest(config, {});
+        let time;
+        time = new Time('1h', moment(), {}, parent,  config);
+        expect(time.title).to.be.equal(null);
+
+        time = new Time('1h', moment(), {}, null,  config);
+        expect(time.title).to.be.equal(null);
+    });
+});
+

--- a/src/models/time.js
+++ b/src/models/time.js
@@ -21,7 +21,7 @@ class time {
      * construct
      * @param timeString
      * @param note
-     * @param parent
+     * @param {hasTimes} parent
      * @param config
      */
     constructor(timeString, date = null, note, parent, config) {
@@ -66,6 +66,15 @@ class time {
 
     get time() {
         return time.toHumanReadable(this.seconds, this._hoursPerDay, this._timeFormat);
+    }
+
+    /**
+     * Title of the linked Noteable object (Issue/MergeRequest)
+     *
+     * @returns {String|null}
+     */
+    get title() {
+        return this.parent && this.parent.title || null;
     }
 
     get _timeFormat() {


### PR DESCRIPTION
### Description

This pull requests adds support of the column "title" in the "recordColumns".

### Fixed Issues

1. Fixes kriskbx/gitlab-time-tracker#126

### Manual testing scenarios

```sh
<gtt_bin> report <project> --type=project --report=records --record_columns=iid --record_columns=type --record_columns=title -o table
```
