### PR TITLE
#105: Report: Add date shortcut last_month

### DIFF
--- a/spec/commands/report.date.shortcuts.spec.js
+++ b/spec/commands/report.date.shortcuts.spec.js
@@ -1,0 +1,62 @@
+const Sinon = require('sinon');
+const program = require('commander');
+const { assert } = require('chai');
+const Config = require('../../src/include/file-config');
+const moment = require('moment');
+const report = require('../../src/models/report');
+
+describe('Command Report. Date shortcuts', () => {
+    it('Shortcut last_month registered', () => {
+        /** @type {Sinon.SinonMock} */
+        const stub = Sinon.mock(program);
+
+        /** @type {Sinon.SinonSpy} */
+        const spy = Sinon.spy(program, 'option');
+
+        stub.expects('parse').throws('Test exception to prevent further execution of gtt-report')
+        try {
+            require('../../src/gtt-report');
+        } catch (e) {}
+
+        try {
+            assert(spy.calledWith('--last_month'), 'last_month not registered');
+        } finally {
+            spy.restore();
+            stub.restore();
+        }
+    });
+
+    it('Shortcut last_month. Sets From and To to Config', () => {
+        program.last_month = true;
+        program.args = [];
+        let configSpy = Sinon.spy(Config.prototype, 'set');
+
+        const reportOriginal = Object.getPrototypeOf(report);
+        let reportStub = Sinon.stub().callsFake(() => {
+            throw new Error('Test exception to prevent further execution of gtt-report')
+        });
+        Object.setPrototypeOf(report, reportStub);
+
+        stub = Sinon.mock(program);
+        stub.expects('parse').returnsThis();
+
+        try {
+            require('../../src/gtt-report');
+        } catch (e) {}
+
+        try {
+            assert(
+                configSpy.calledWith('from', moment().subtract(1, 'months').startOf('month')),
+                'From is not set to Config'
+            );
+            assert(
+                configSpy.calledWith('to', moment().subtract(1, 'months').endOf('month')),
+                'To is not set to Config'
+            );
+        } finally {
+            configSpy.restore();
+            Object.setPrototypeOf(report, reportOriginal);
+            delete require.cache[require.resolve('../../src/models/report')];
+        }
+    })
+})

--- a/src/gtt-report.js
+++ b/src/gtt-report.js
@@ -40,6 +40,7 @@ program
     .option('--today', 'ignores --from and --to and queries entries for today')
     .option('--this_week', 'ignores --from and --to and queries entries for this week')
     .option('--this_month', 'ignores --from and --to and queries entries for this month')
+    .option('--last_month', 'ignores --from and --to and queries entries for last month')
     .option('-c --closed', 'include closed issues')
     .option('-m --milestone <milestone>', 'include issues from the given milestone')
     .option('--hours_per_day <hours>', 'hours per day for human readable time formats')
@@ -138,6 +139,10 @@ if (program.this_month)
     config
         .set('from', moment().startOf('month'))
         .set('to', moment().endOf('month'));
+if (program.last_month)
+    config
+        .set('from', moment().subtract(1, 'months').startOf('month'))
+        .set('to', moment().subtract(1, 'months').endOf('month'));
 
 Cli.quiet = config.get('quiet');
 Cli.verbose = config.get('_verbose');


### PR DESCRIPTION
### Description

This pull requests adds support of the date shortcut "last_month" to the command `gtt report`.

Fixes kriskbx/gitlab-time-tracker#105

### Manual testing

```sh
<gtt_bin> report <project> --type=project --report=stats --last_month -o table
```
